### PR TITLE
Pass bounded variables from loop fun to global context

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         otp: ['22.2']
-        elixir: ['1.9', '1.11', '1.13']
+        elixir: ['1.11', '1.12', '1.13']
         include:
           - otp: '20.3'
             elixir: '1.9'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The package can be installed by adding `assert_eventually` to your list of depen
 ```elixir
 def deps do
   [
-    {:assert_eventually, "~> 0.3.0", only: :test}
+    {:assert_eventually, "~> 1.0.0", only: :test}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExAssertEventually.MixProject do
   def project do
     [
       app: :assert_eventually,
-      version: "0.3.1",
+      version: "1.0.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/assert_eventually_different_data_types_test.exs
+++ b/test/assert_eventually_different_data_types_test.exs
@@ -40,8 +40,6 @@ defmodule AssertEventually.DifferentDataTypesTest do
                       }
 
     assert :ok == a
-
-    assert_eventually a
   end
 
   test "lists" do
@@ -66,5 +64,17 @@ defmodule AssertEventually.DifferentDataTypesTest do
     assert_eventually %{a: ^a} = %TestStruct{a: 5}
     assert_eventually %TestStruct{a: ^a} = %TestStruct{a: 5}
     assert_eventually [^a, ^a, ^a] = [5, 5, 5]
+  end
+
+  test "binaries" do
+    n = 8
+
+    assert_eventually <<a>> = <<15>>
+    assert a == 15
+
+    assert_eventually <<a::size(n), b::8, c::16>> = <<1, 2, 3, 4>>
+    assert a == 1
+    assert b == 2
+    assert c == 772
   end
 end

--- a/test/assert_eventually_with_defaults_test.exs
+++ b/test/assert_eventually_with_defaults_test.exs
@@ -5,6 +5,43 @@ defmodule AssertEventually.WithDefaultsTest do
 
   alias AssertEventually.Utils.MockOperation
 
+  describe "leaves properly assigned variables" do
+    test "without = operator" do
+      send(self(), {1, [2, 3], %{d: 4}})
+      eventually assert_received {a, [b, c], %{d: d}}
+
+      assert a == 1
+      assert b == 2
+      assert c == 3
+      assert d == 4
+    end
+
+    test "with = operator" do
+      eventually assert {a, [b, c], %{d: d}} = {1, [2, 3], %{d: 4}}
+      assert a == 1
+      assert b == 2
+      assert c == 3
+      assert d == 4
+    end
+
+    test "with many = operators (arguments)" do
+      eventually assert_in_delta a = 1, b = 2, c = 3
+
+      assert a == 1
+      assert b == 2
+      assert c == 3
+    end
+
+    test "with many = operators (nested)" do
+      eventually assert {a = b, [b, c], %{d: d = _e}} = {1, [1, 3], %{d: 4}}
+
+      assert a == 1
+      assert b == 1
+      assert c == 3
+      assert d == 4
+    end
+  end
+
   describe "happy case using eventually(assert_in_delta)" do
     test "when trivial range is passed" do
       eventually(assert_in_delta 5, 2, 3)


### PR DESCRIPTION
This PR removes need to silence variables inside of main loop (which reduces complexity) and fixes usage with multi-args asserts or nested matches.